### PR TITLE
feat(release): add build step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,28 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Run tests
+        run: npm test
+        
+      - name: Build action
+        run: npm run build
+        
+      - name: Commit built files
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add dist/
+          git commit -m "build: update dist for release" || exit 0
           
       - uses: dnogu/semantic-release-action@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,68 @@
-# Build and Release Folders
-bin-debug/
-bin-release/
-[Oo]bj/
-[Bb]in/
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
 
-# Other files and folders
-.settings/
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
 
-# Executables
-*.swf
-*.air
-*.ipa
-*.apk
+# Coverage directory used by tools like istanbul
+coverage/
+*.lcov
 
-# Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
-# should NOT be excluded as they contain compiler settings and other important
-# information for Eclipse / Flash Builder.
+# nyc test coverage
+.nyc_output
+
+# Logs
+logs
+*.log
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env
+.env.test
+.env.local
+.env.production
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Keep dist/ for GitHub Actions - it contains the bundled code
+# dist/ should be committed for GitHub Actions to work properly


### PR DESCRIPTION
- Add Node.js setup and dependency installation before semantic release
- Include test execution to ensure code quality before release
- Build action with npm run build to generate dist/index.js bundle
- Commit built dist/ files automatically before creating release
- Update .gitignore for proper Node.js/GitHub Action project structure

This fixes the issue where releases were created without built dist/ files, causing 'Could not find file' errors when users try to use the action. Now every release will have a properly built and tested dist/index.js file.

