### PR TITLE
docs: capitalize example section headers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ jobs:
 ### Basic Tofu Init
 ```yaml
 steps:
-  - name: Run basic tofu init
+  - name: Run Basic Tofu Init
     uses: dnogu/github-tofu-init@v1
     with:
       working-directory: ./infra


### PR DESCRIPTION
- Change "Basic tofu init" to "Basic Tofu Init"
- Change "tofu init with backend config" to "Tofu Init With Backend Config"
- Improve consistency with proper title case formatting

