### PR TITLE
docs: improve examples with complete workflow setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,16 @@ jobs:
 ### Basic Tofu Init
 ```yaml
 steps:
+  - name: Checkout code
+    uses: actions/checkout@v4
+  
+  - name: Setup OpenTofu
+    uses: opentofu/setup-opentofu@v1
+    with:
+      tofu_version: '1.8.0'
+  
   - name: Run Basic Tofu Init
-    uses: dnogu/github-tofu-init@v1
+    uses: dnogu/tofu-init@v1
     with:
       working-directory: ./infra
 ```
@@ -94,8 +102,16 @@ steps:
 ### Tofu Init With Backend Config
 ```yaml
 steps:
+  - name: Checkout code
+    uses: actions/checkout@v4
+  
+  - name: Setup OpenTofu
+    uses: opentofu/setup-opentofu@v1
+    with:
+      tofu_version: '1.8.0'
+  
   - name: Run tofu init with backend config
-    uses: dnogu/github-tofu-init@v1
+    uses: dnogu/tofu-init@v1
     with:
       working-directory: ./infra
       backend-config: "bucket=my-bucket,region=us-east-1"


### PR DESCRIPTION
- Add setup-opentofu@v1 step to all examples with version 1.8.0
- Add explicit checkout step for complete workflow examples
- Fix action reference from 'dnogu/github-tofu-init@v1' to 'dnogu/tofu-init@v1'
- Add descriptive step names for better clarity
- Ensure examples are copy-paste ready and will work without errors

This provides users with complete, working examples that include all necessary setup steps rather than incomplete snippets that would fail without OpenTofu installation.

