### PR TITLE
fix: ensure dist/ folder is properly built and committed for all releases

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -68,7 +68,6 @@ jobs:
         run: npm run build
         
       - name: Check for dist changes
-        if: github.event_name == 'pull_request'
         id: check-changes
         run: |
           if git diff --quiet dist/; then
@@ -80,12 +79,16 @@ jobs:
           fi
           
       - name: Commit built files
-        if: github.event_name == 'pull_request' && steps.check-changes.outputs.has-changes == 'true'
+        if: steps.check-changes.outputs.has-changes == 'true'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add dist/
-          git commit -m "build: update dist for PR changes"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git commit -m "build: update dist for PR changes"
+          else
+            git commit -m "build: update dist for main branch"
+          fi
           git push
           
       - name: Comment on PR


### PR DESCRIPTION
## Problem
The 'Could not find file' error occurs because the dist/ folder wasn't being built and committed when changes are pushed to main branch.

## Solution
- Fixed build-pr.yml to commit dist/ changes on both PRs AND main branch pushes
- Kept release.yml simple since semantic-release-action expects pre-built dist/
- This ensures the dist/ folder is always up-to-date before releases are created

## Testing
This PR should trigger the build-pr.yml workflow to build and commit the dist/ folder, then when merged, the release workflow should create a proper v1.2.1 release with the dist/ folder included.

Fixes the 'Could not find file' errors when users consume the tofu-init action.