### PR TITLE
fix: resolve race condition in build and release workflows

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -3,8 +3,6 @@ name: Build and Validate PR
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 jobs:
   test-and-build:
@@ -84,11 +82,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add dist/
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git commit -m "build: update dist for PR changes"
-          else
-            git commit -m "build: update dist for main branch"
-          fi
+          git commit -m "build: update dist for PR changes"
           git push
           
       - name: Comment on PR


### PR DESCRIPTION
## Problem
Fixed race condition where build-pr.yml and release.yml were running simultaneously on merge, causing 'Could not find file' errors.

## Solution
- Removed push trigger from build-pr.yml to eliminate race condition
- build-pr.yml now only runs during PRs to build and commit dist/ before merge
- release.yml runs after merge with pre-built dist/ folder ready

## Testing
This should create a proper v1.2.1 release with the dist/ folder included, fixing the action distribution issues.